### PR TITLE
Fix Mode B for batched HDF5 datasets

### DIFF
--- a/tiled_poc/broker/bulk_register.py
+++ b/tiled_poc/broker/bulk_register.py
@@ -259,7 +259,7 @@ def prepare_node_data(ent_df, art_df, max_entities, base_dir=None):
                 # Build data source parameters
                 ds_params = {"dataset": dataset_path}
                 if index is not None:
-                    ds_params["index"] = index
+                    ds_params["slice"] = str(int(index))
 
                 art_nodes.append({
                     "key": art_key,

--- a/tiled_poc/broker/bulk_register.py
+++ b/tiled_poc/broker/bulk_register.py
@@ -382,14 +382,15 @@ def bulk_register(engine, ent_nodes, art_nodes, art_data_sources):
             node_id = art_id_map[(ds["parent_uid"], ds["art_key"])]
             result = conn.execute(
                 text("""
-                    INSERT INTO data_sources (node_id, structure_id, mimetype, parameters, management, structure_family)
-                    VALUES (:node_id, :structure_id, :mimetype, :parameters, :management, :structure_family)
+                    INSERT INTO data_sources (node_id, structure_id, mimetype, parameters, properties, management, structure_family)
+                    VALUES (:node_id, :structure_id, :mimetype, :parameters, :properties, :management, :structure_family)
                 """),
                 {
                     "node_id": node_id,
                     "structure_id": ds["structure_id"],
                     "mimetype": "application/x-hdf5",
                     "parameters": json.dumps(ds["parameters"]),
+                    "properties": json.dumps({}),
                     "management": "external",
                     "structure_family": "array",
                 }

--- a/tiled_poc/broker/http_register.py
+++ b/tiled_poc/broker/http_register.py
@@ -75,7 +75,7 @@ def create_data_source(art_row, base_dir):
     # Build parameters
     ds_params = {"dataset": dataset_path}
     if index is not None:
-        ds_params["index"] = index
+        ds_params["slice"] = str(int(index))
 
     # Create data source
     data_source = DataSource(

--- a/tiled_poc/tests/test_generic_registration.py
+++ b/tiled_poc/tests/test_generic_registration.py
@@ -284,8 +284,8 @@ class TestNiPS3Registration:
         assert shapes["rixs"] == [6, 5]  # (5, 6, 5) -> (6, 5) per entity
         assert shapes["mag"] == [10]  # (5, 10) -> (10,) per entity
 
-    def test_data_source_has_index_parameter(self, nips3_manifests):
-        """Data sources for batched files include index in parameters."""
+    def test_data_source_has_slice_parameter(self, nips3_manifests):
+        """Data sources for batched files include slice in parameters."""
         from broker.bulk_register import prepare_node_data
         ent_df, art_df, base_dir = nips3_manifests
 
@@ -294,17 +294,17 @@ class TestNiPS3Registration:
         )
 
         for ds in art_ds:
-            assert "index" in ds["parameters"]
+            assert "slice" in ds["parameters"]
 
-        # First entity's artifacts should have index=0
+        # First entity's artifacts should have slice="0"
         first_ent_ds = [ds for ds in art_ds if ds["parent_uid"] == "rank0000_0000"]
         for ds in first_ent_ds:
-            assert ds["parameters"]["index"] == 0
+            assert ds["parameters"]["slice"] == "0"
 
-        # Second entity's artifacts should have index=1
+        # Second entity's artifacts should have slice="1"
         second_ent_ds = [ds for ds in art_ds if ds["parent_uid"] == "rank0000_0001"]
         for ds in second_ent_ds:
-            assert ds["parameters"]["index"] == 1
+            assert ds["parameters"]["slice"] == "1"
 
     def test_shared_assets_for_batched_files(self, nips3_manifests):
         """Batched files: multiple artifacts share the same HDF5 file."""


### PR DESCRIPTION
## Summary

Two bugs were preventing Mode B (Tiled HTTP adapter) from working with batched/indexed HDF5 datasets like EDRIXS:

- **Wrong DataSource parameter name:** Registration code stored `parameters={"index": 42}`, but Tiled's `HDF5ArrayAdapter.from_catalog()` expects `slice`. The unknown kwarg caused a TypeError. Fixed by translating our manifest's `index` to Tiled's `slice` at registration time: `ds_params["slice"] = str(int(index))`.
- **Missing `properties` column:** `bulk_register.py` omitted the `properties` column when inserting into `data_sources`. Tiled's Pydantic schema requires it to be a dict (not NULL), causing a `ValidationError` before the adapter was even called. Fixed by adding `properties: '{}'` to the INSERT.

No Tiled source changes needed -- both fixes are in our registration layer.

**Files changed:**
- `broker/bulk_register.py` -- `"index"` to `"slice"` in DataSource params + added `properties` column
- `broker/http_register.py` -- `"index"` to `"slice"` in DataSource params
- `tests/test_generic_registration.py` -- updated test to expect `"slice"` key

Fixes #2

## Test plan

- [x] 19/19 unit tests pass (VDP + NiPS3 + cross-dataset)
- [x] End-to-end: registered 10 EDRIXS entities, started Tiled server, queried via Mode B
- [x] `client["H_edx00000"]["rixs"][:]` returns shape `(151, 40)` (was HTTP 500)
- [x] Mode B data matches h5py direct reads for indices 0, 5, and 9
- [x] Full-scale ingestion with all EDRIXS entities

Generated with [Claude Code](https://claude.com/claude-code)